### PR TITLE
Publish output/ on GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,7 +24,6 @@ exclude:
   - skills/
   - tests/
   - node_modules/
-  - output/
   - "*.py"
   - "*.j2"
   - "*.feature"


### PR DESCRIPTION
## Summary

- Remove `output/` from Jekyll exclude list in `_config.yml` so scan reports are accessible via GitHub Pages

Fixes 404 at https://chrisbarlow.nz/di-test/output/accessibility-scan-report.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)